### PR TITLE
Use `rfc2822` date format (#108)

### DIFF
--- a/ghp_import.py
+++ b/ghp_import.py
@@ -176,7 +176,7 @@ def gitpath(fname):
 
 def run_import(git, srcdir, **opts):
     srcdir = dec(srcdir)
-    pipe = git.open('fast-import', '--date-format=raw', '--quiet',
+    pipe = git.open('fast-import', '--date-format=rfc2822', '--quiet',
                     stdin=sp.PIPE, stdout=None, stderr=None)
     start_commit(pipe, git, opts['branch'], opts['mesg'], opts['prefix'])
     for path, _, fnames in os.walk(srcdir, followlinks=opts['followlinks']):


### PR DESCRIPTION
Change git-fast-import(1) --date-format from `raw` to `rfc22822` to support more GIT_COMMITTER_DATE date values.